### PR TITLE
Ensure MQTT client disposes correctly without DisposeAsync

### DIFF
--- a/src/PCVolumeMqtt/Program.cs
+++ b/src/PCVolumeMqtt/Program.cs
@@ -119,7 +119,8 @@ internal static class Program
         Application.ApplicationExit += (_, _) =>
         {
             icon.Visible = false;
-            mqttClient.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            mqttClient.DisconnectAsync().GetAwaiter().GetResult();
+            mqttClient.Dispose();
         };
 
         Application.Run();


### PR DESCRIPTION
## Summary
- replace missing `DisposeAsync` call with synchronous `DisconnectAsync` and `Dispose` to clean up the MQTT client on exit

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dbb2f8a4832ba6e6ecb3b99b944f