### PR TITLE
Add settings option to tray icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Utility to expose Windows PC sound device volumes to Home Assistant via MQTT.
    dialogs to collect your MQTT host, port, username, password, and a machine
    name. These values are stored in `config.json` alongside the executable for
    future runs. The app registers itself to start on login and runs in the
-   system tray; right‑click the tray icon to exit.
+   system tray; right‑click the tray icon to open settings or exit. The
+   settings dialog can be used later to change MQTT details or rename the
+   machine.
 
 Home Assistant will automatically discover each active sound device through MQTT
 discovery and expose a numeric entity to view or change that device's volume.

--- a/src/PCVolumeMqtt/Program.cs
+++ b/src/PCVolumeMqtt/Program.cs
@@ -132,6 +132,13 @@ internal static class Program
             Text = "PC Volume MQTT",
             ContextMenuStrip = new ContextMenuStrip()
         };
+        icon.ContextMenuStrip.Items.Add("Settings...", null, (_, _) =>
+        {
+            PromptForConfig(config);
+            SaveConfig(config, configPath);
+            Application.Restart();
+            Application.Exit();
+        });
         icon.ContextMenuStrip.Items.Add("Exit", null, (_, _) => Application.Exit());
 
         Application.ApplicationExit += (_, _) =>


### PR DESCRIPTION
## Summary
- add Settings menu to tray icon allowing reconfiguration and renaming
- document Settings usage

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9df303098832b8c0366fc07860329