### PR TITLE
Arrange publish output into content subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Utility to expose Windows PC sound device volumes to Home Assistant via MQTT.
 
 ## Setup
 
-1. Publish a single-file executable for Windows (requires .NET SDK 8.0 or later):
+1. Publish the application for Windows (requires .NET SDK 8.0 or later):
 
    ```sh
-   dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:SelfContained=true -p:IncludeNativeLibrariesForSelfExtract=true
+   dotnet publish -c Release -r win-x64
    ```
 
-   The resulting `PCVolumeMqtt.exe` will be in
-   `src/PCVolumeMqtt/bin/Release/net8.0-windows10.0.19041.0/win-x64/publish/`.
+   The publish output will be in
+   `src/PCVolumeMqtt/bin/Release/net8.0-windows10.0.19041.0/win-x64/publish/`
+   with `PCVolumeMqtt.exe` at the root and a `content` subfolder containing
+   all other files.
 
 2. Copy the executable to the target PC and run it. On first launch it displays
    dialogs to collect your MQTT host, port, username, password, and a machine

--- a/src/PCVolumeMqtt/PCVolumeMqtt.csproj
+++ b/src/PCVolumeMqtt/PCVolumeMqtt.csproj
@@ -15,4 +15,15 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 
+  <Target Name="ArrangePublishLayout" AfterTargets="Publish">
+    <PropertyGroup>
+      <ContentDir>$(PublishDir)content/</ContentDir>
+      <ArrangePublishCmd><![CDATA[bash -c 'shopt -s dotglob; for f in "$(PublishDir)"*; do if [ "$$f" != "$(PublishDir)$(AssemblyName).exe" ]; then mv "$$f" "$(ContentDir)"; fi; done']]></ArrangePublishCmd>
+      <ArrangePublishCmdWindows><![CDATA[powershell -NoProfile -Command "Get-ChildItem -Path '$(PublishDir)' -Exclude '$(AssemblyName).exe','content' | Move-Item -Destination '$(ContentDir)'" ]]></ArrangePublishCmdWindows>
+    </PropertyGroup>
+    <MakeDir Directories="$(ContentDir)" />
+    <Exec Command="$(ArrangePublishCmd)" Condition="'$(OS)' != 'Windows_NT'" />
+    <Exec Command="$(ArrangePublishCmdWindows)" Condition="'$(OS)' == 'Windows_NT'" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Summary
- add publish target that moves non-executable artifacts into a `content` subfolder
- document new publish layout in README

## Testing
- `dotnet publish -c Release -r win-x64` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaee5b25e8832b800c4c660fc04c14