### PR TITLE
Support pre-config file and single-file build

### DIFF
--- a/pre-config-example.txt
+++ b/pre-config-example.txt
@@ -1,0 +1,7 @@
+# Example pre-configuration for PCVolumeMqtt
+# Copy this file to pre-config.txt and fill in the values.
+# Lines beginning with # are comments. A # denotes a comment anywhere unless inside quotes.
+# mqtt_host=your.mqtt.host
+# mqtt_username=your_username
+# mqtt_password="your#password"
+# machine_name=My-PC

--- a/src/PCVolumeMqtt/PCVolumeMqtt.csproj
+++ b/src/PCVolumeMqtt/PCVolumeMqtt.csproj
@@ -8,6 +8,9 @@
     <Nullable>enable</Nullable>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UseWindowsForms>true</UseWindowsForms>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Load optional `pre-config.txt` for MQTT and machine settings before prompting
- Configure project for self-contained single-file Windows build
- Document example `pre-config.txt` format

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf3e346d8832bbb6c45881d09d448