### PR TITLE
Ensure pre-config template is published with executable

### DIFF
--- a/src/PCVolumeMqtt/PCVolumeMqtt.csproj
+++ b/src/PCVolumeMqtt/PCVolumeMqtt.csproj
@@ -18,11 +18,18 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="pre-config.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <Target Name="ArrangePublishLayout" AfterTargets="Publish">
     <PropertyGroup>
       <ContentDir>$(PublishDir)content/</ContentDir>
-      <ArrangePublishCmd><![CDATA[bash -c 'shopt -s dotglob; for f in "$(PublishDir)"*; do if [ "$$f" != "$(PublishDir)$(AssemblyName).exe" ]; then mv "$$f" "$(ContentDir)"; fi; done']]></ArrangePublishCmd>
-      <ArrangePublishCmdWindows><![CDATA[powershell -NoProfile -Command "Get-ChildItem -Path '$(PublishDir)' -Exclude '$(AssemblyName).exe','content' | Move-Item -Destination '$(ContentDir)'" ]]></ArrangePublishCmdWindows>
+      <ArrangePublishCmd><![CDATA[bash -c 'shopt -s dotglob; for f in "$(PublishDir)"*; do if [ "$$f" != "$(PublishDir)$(AssemblyName).exe" ] && [ "$$f" != "$(PublishDir)pre-config.txt" ]; then mv "$$f" "$(ContentDir)"; fi; done']]></ArrangePublishCmd>
+      <ArrangePublishCmdWindows><![CDATA[powershell -NoProfile -Command "Get-ChildItem -Path '$(PublishDir)' -Exclude '$(AssemblyName).exe','content','pre-config.txt' | Move-Item -Destination '$(ContentDir)'" ]]></ArrangePublishCmdWindows>
     </PropertyGroup>
     <MakeDir Directories="$(ContentDir)" />
     <Exec Command="$(ArrangePublishCmd)" Condition="'$(OS)' != 'Windows_NT'" />

--- a/src/PCVolumeMqtt/pre-config.txt
+++ b/src/PCVolumeMqtt/pre-config.txt
@@ -1,0 +1,7 @@
+# Pre-configuration for PCVolumeMqtt
+# Uncomment and set the values below to preconfigure the app before first run.
+
+# mqtt_host=
+# mqtt_username=
+# mqtt_password=
+# machine_name=


### PR DESCRIPTION
## Summary
- include a commented `pre-config.txt` template for easy configuration
- copy `pre-config.txt` to build/publish output and keep it beside the executable

## Testing
- `dotnet publish src/PCVolumeMqtt/PCVolumeMqtt.csproj -c Release -o publish` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aafa632118832bb89cedc8887e0331