### PR TITLE
Encrypt stored MQTT password

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Utility to expose Windows PC sound device volumes to Home Assistant via MQTT.
 2. Copy the executable to the target PC and run it. On first launch it displays
    dialogs to collect your MQTT host, port, username, password, and a machine
    name. These values are stored in `config.json` alongside the executable for
-   future runs. The app registers itself to start on login and runs in the
-   system tray; right‑click the tray icon to open settings or exit. The
-   settings dialog can be used later to change MQTT details or rename the
-   machine.
+   future runs. The password is encrypted using the Windows Data Protection API
+   and can only be decrypted by the same user account. The app registers itself
+   to start on login and runs in the system tray; right‑click the tray icon to
+   open settings or exit. The settings dialog can be used later to change MQTT
+   details or rename the machine.
 
 Home Assistant will automatically discover each active sound device through MQTT
 discovery and expose a numeric entity to view or change that device's volume.

--- a/config-example.json
+++ b/config-example.json
@@ -4,6 +4,6 @@
     "host": "mqtt.local",
     "port": 1883,
     "username": "user",
-    "password": "pass"
+    "password": ""
   }
 }

--- a/src/PCVolumeMqtt/AppConfig.cs
+++ b/src/PCVolumeMqtt/AppConfig.cs
@@ -1,3 +1,7 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+
 namespace PCVolumeMqtt;
 
 public class AppConfig
@@ -10,6 +14,41 @@ public class AppConfig
         public string Host { get; set; } = "localhost";
         public int Port { get; set; } = 1883;
         public string Username { get; set; } = string.Empty;
+
+        [JsonIgnore]
         public string Password { get; set; } = string.Empty;
+
+        [JsonIgnore]
+        public bool IsPasswordEncrypted { get; private set; } = true;
+
+        [JsonPropertyName("password")]
+        public string? EncryptedPassword
+        {
+            get => string.IsNullOrEmpty(Password)
+                ? null
+                : Convert.ToBase64String(ProtectedData.Protect(Encoding.UTF8.GetBytes(Password), null, DataProtectionScope.CurrentUser));
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    Password = string.Empty;
+                    IsPasswordEncrypted = true;
+                    return;
+                }
+
+                try
+                {
+                    var bytes = Convert.FromBase64String(value);
+                    var decrypted = ProtectedData.Unprotect(bytes, null, DataProtectionScope.CurrentUser);
+                    Password = Encoding.UTF8.GetString(decrypted);
+                    IsPasswordEncrypted = true;
+                }
+                catch
+                {
+                    Password = value;
+                    IsPasswordEncrypted = false;
+                }
+            }
+        }
     }
 }

--- a/src/PCVolumeMqtt/Program.cs
+++ b/src/PCVolumeMqtt/Program.cs
@@ -35,6 +35,11 @@ internal static class Program
                 config.MachineName = name;
         }
 
+        if (configExists && !config.Mqtt.IsPasswordEncrypted && !string.IsNullOrEmpty(config.Mqtt.Password))
+        {
+            SaveConfig(config, configPath);
+        }
+
         var missing = string.IsNullOrWhiteSpace(config.Mqtt.Host)
                       || string.IsNullOrWhiteSpace(config.Mqtt.Username)
                       || string.IsNullOrWhiteSpace(config.Mqtt.Password)


### PR DESCRIPTION
## Summary
- encrypt MQTT password using Windows DPAPI when saving config
- auto-resave existing configs with plaintext passwords
- document password encryption and remove example password

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aafc90fd64832baf3e8cd357b76ef4