### PR TITLE
Make volume topic name constant

### DIFF
--- a/src/PCVolumeMqtt/Program.cs
+++ b/src/PCVolumeMqtt/Program.cs
@@ -68,7 +68,7 @@ internal static class Program
         await mqttClient.ConnectAsync(options);
 
         var slug = Slugify(config.MachineName);
-        const string baseTopic = "volume";
+        var baseTopic = $"pc/{slug}/volume";
 
         using var volume = new VolumeService();
 
@@ -85,7 +85,7 @@ internal static class Program
             await mqttClient.PublishAsync(msg);
         }
 
-        const string objectId = "volume";
+        var objectId = $"{slug}_volume";
         var discoveryTopic = $"homeassistant/number/{objectId}/config";
         var discoveryPayload = JsonSerializer.Serialize(new
         {

--- a/src/PCVolumeMqtt/Program.cs
+++ b/src/PCVolumeMqtt/Program.cs
@@ -68,11 +68,10 @@ internal static class Program
         await mqttClient.ConnectAsync(options);
 
         var slug = Slugify(config.MachineName);
-        var baseTopic = $"pc/{slug}/volume";
+        const string baseTopic = "volume";
 
         using var volume = new VolumeService();
 
-        var device = volume.GetDevice();
         var stateTopic = $"{baseTopic}/state";
         var commandTopic = $"{baseTopic}/set";
 
@@ -86,11 +85,11 @@ internal static class Program
             await mqttClient.PublishAsync(msg);
         }
 
-        var objectId = $"{slug}_volume";
+        const string objectId = "volume";
         var discoveryTopic = $"homeassistant/number/{objectId}/config";
         var discoveryPayload = JsonSerializer.Serialize(new
         {
-            name = $"{device.Name} Volume",
+            name = "volume",
             command_topic = commandTopic,
             state_topic = stateTopic,
             min = 0,


### PR DESCRIPTION
## Summary
- Use a fixed `volume` topic instead of names derived from the audio output device
- Publish discovery payload with constant name and unique ID `volume`

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaff4db664832b8446172daae8a215