### PR TITLE
Handle default audio device changes by id

### DIFF
--- a/src/PCVolumeMqtt/VolumeService.cs
+++ b/src/PCVolumeMqtt/VolumeService.cs
@@ -45,13 +45,16 @@ public class VolumeService : IDisposable
         _enumerator.Dispose();
     }
 
-    private void RefreshDevice()
+    private void RefreshDevice(string deviceId)
     {
-        var newDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
-        if (newDevice.ID == _device.ID)
+        MMDevice newDevice;
+        try
         {
-            newDevice.Dispose();
-            return;
+            newDevice = _enumerator.GetDevice(deviceId);
+        }
+        catch
+        {
+            newDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
         }
 
         _device.AudioEndpointVolume.OnVolumeNotification -= _callback;
@@ -63,9 +66,9 @@ public class VolumeService : IDisposable
 
     private class NotificationClient : IMMNotificationClient
     {
-        private readonly Action _onDefaultDeviceChanged;
+        private readonly Action<string> _onDefaultDeviceChanged;
 
-        public NotificationClient(Action onDefaultDeviceChanged)
+        public NotificationClient(Action<string> onDefaultDeviceChanged)
         {
             _onDefaultDeviceChanged = onDefaultDeviceChanged;
         }
@@ -75,7 +78,7 @@ public class VolumeService : IDisposable
             if (flow == DataFlow.Render &&
                 (role == Role.Console || role == Role.Multimedia))
             {
-                _onDefaultDeviceChanged();
+                _onDefaultDeviceChanged(defaultDeviceId);
             }
         }
 


### PR DESCRIPTION
## Summary
- Refresh volume notifications using the device id reported by Windows when the default audio device changes
- Re-register volume callbacks to ensure MQTT updates continue after switching audio devices

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abad9aa840832b983bd8dd22118840