### PR TITLE
Fix deadlock when refreshing audio device

### DIFF
--- a/src/PCVolumeMqtt/VolumeService.cs
+++ b/src/PCVolumeMqtt/VolumeService.cs
@@ -1,6 +1,7 @@
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace PCVolumeMqtt;
 
@@ -27,7 +28,10 @@ public class VolumeService : IDisposable
             Trace.WriteLine($"OnVolumeNotification {vol}");
             VolumeChanged?.Invoke(this, new VolumeChangedEventArgs(vol));
         };
-        _notificationClient = new NotificationClient(RefreshDevice);
+        _notificationClient = new NotificationClient(d =>
+        {
+            Task.Run(() => RefreshDevice(d));
+        });
         _enumerator.RegisterEndpointNotificationCallback(_notificationClient);
         _device = _enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
         _device.AudioEndpointVolume.OnVolumeNotification += _callback;


### PR DESCRIPTION
## Summary
- run device refresh on background thread to avoid deadlock when switching audio outputs

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb87256ac832ba2d06ec69b724553