### PR TITLE
Add self-install and uninstall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Utility to expose Windows PC sound device volumes to Home Assistant via MQTT.
    name. These values are stored in `config.json` alongside the executable for
    future runs. The password is encrypted using the Windows Data Protection API
    and can only be decrypted by the same user account. The app registers itself
-   to start on login and runs in the system tray; right‑click the tray icon to
+   to start on login and creates an entry in Add/Remove Programs so it can be
+   uninstalled later. It runs in the system tray; right‑click the tray icon to
    open settings or exit. The settings dialog can be used later to change MQTT
    details or rename the machine.
+
+3. To uninstall, either use **Add/Remove Programs** or run the executable with
+   the `--uninstall` flag.
 
 Home Assistant will automatically discover each active sound device through MQTT
 discovery and expose a numeric entity to view or change that device's volume.

--- a/src/PCVolumeMqtt/Installer.cs
+++ b/src/PCVolumeMqtt/Installer.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+using System.Windows.Forms;
+using Microsoft.Win32;
+
+namespace PCVolumeMqtt;
+
+internal static class Installer
+{
+    private const string RunKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
+    private const string UninstallKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PCVolumeMqtt";
+
+    internal static void RegisterApplication()
+    {
+        using (var run = Registry.CurrentUser.OpenSubKey(RunKey, writable: true))
+        {
+            run?.SetValue("PCVolumeMqtt", Application.ExecutablePath);
+        }
+
+        using (var uninstall = Registry.CurrentUser.CreateSubKey(UninstallKey))
+        {
+            uninstall?.SetValue("DisplayName", "PC Volume MQTT");
+            uninstall?.SetValue("DisplayIcon", Application.ExecutablePath);
+            uninstall?.SetValue("Publisher", "pc-ha-control");
+            uninstall?.SetValue("UninstallString", $"\"{Application.ExecutablePath}\" --uninstall");
+        }
+    }
+
+    internal static void UninstallApplication()
+    {
+        using (var run = Registry.CurrentUser.OpenSubKey(RunKey, writable: true))
+        {
+            run?.DeleteValue("PCVolumeMqtt", false);
+        }
+        Registry.CurrentUser.DeleteSubKeyTree(UninstallKey, false);
+
+        var exe = Application.ExecutablePath;
+        var cmd = $"/C timeout 2 && del \"{exe}\"";
+        Process.Start(new ProcessStartInfo("cmd.exe", cmd) { CreateNoWindow = true });
+    }
+}

--- a/src/PCVolumeMqtt/Program.cs
+++ b/src/PCVolumeMqtt/Program.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Windows.Forms;
 using MQTTnet;
 using MQTTnet.Client;
-using Microsoft.Win32;
 using PCVolumeMqtt;
 using System.Linq;
 using System.Collections.Generic;
@@ -12,7 +11,7 @@ using System.Diagnostics;
 internal static class Program
 {
     [STAThread]
-    private static async Task Main()
+    private static async Task Main(string[] args)
     {
         var logPath = Path.Combine(AppContext.BaseDirectory, "trace.log");
         Trace.Listeners.Add(new TextWriterTraceListener(logPath));
@@ -67,7 +66,13 @@ internal static class Program
             }
         }
 
-        EnsureStartup();
+        if (args.Contains("--uninstall"))
+        {
+            Installer.UninstallApplication();
+            return;
+        }
+
+        Installer.RegisterApplication();
         Trace.WriteLine("Starting MQTT connection");
 
         var mqttFactory = new MqttFactory();
@@ -235,12 +240,6 @@ internal static class Program
     private static string Slugify(string input)
     {
         return string.Concat(input.ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '_'));
-    }
-
-    private static void EnsureStartup()
-    {
-        using var key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
-        key?.SetValue("PCVolumeMqtt", Application.ExecutablePath);
     }
 
     private static Dictionary<string, string> LoadPreConfig(string path)


### PR DESCRIPTION
## Summary
- add installer helper to register startup and Add/Remove Programs entries
- allow `--uninstall` argument to remove registry entries and delete executable
- document new install/uninstall behavior

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe0d56b4832babd3b88bef6ea884